### PR TITLE
Revise: improvements to the implimentation of setUserWindowTitle(...)

### DIFF
--- a/src/TConsole.cpp
+++ b/src/TConsole.cpp
@@ -3000,3 +3000,39 @@ void TConsole::dropEvent(QDropEvent* e)
         }
     }
 }
+
+std::pair<bool, QString> TConsole::setUserWindowTitle(const QString& name, const QString& text)
+{
+    if (name.isEmpty()) {
+        return {false, QStringLiteral("a user window cannot have an empty string as its name")};
+    }
+
+    auto pC = mSubConsoleMap.value(name);
+    if (!pC) {
+        return {false, QStringLiteral("user window name \"%1\" not found").arg(name)};
+    }
+
+    // If it does not have an mType of UserWindow then it does not in a
+    // floatable/dockable widget - so it can't have a titlebar...!
+    if (pC->getType() != UserWindow) {
+        return {false, QStringLiteral("\"%1\" is not a user window").arg(name)};
+    }
+
+    auto pD = mDockWidgetMap.value(name);
+    if (Q_LIKELY(pD)) {
+        if (text.isEmpty()) {
+            // Reset to default text:
+            pD->setWindowTitle(tr("User window - %1 - %2").arg(mpHost->getName(), name));
+            return {true, QString()};
+        }
+
+        pD->setWindowTitle(text);
+        return {true, QString()};
+    }
+
+    // This should be:
+    Q_UNREACHABLE();
+    // as it means that the TConsole is flagged as being a user window yet
+    // it does not have a TDockWidget to hold it...
+    return {false, QStringLiteral("internal error: TConsole \"%1\" is marked as a user window but does not have a TDockWidget to contain it").arg(name)};
+}

--- a/src/TConsole.h
+++ b/src/TConsole.h
@@ -214,6 +214,7 @@ public:
     // 2 = Selection not valid
     QPair<quint8, TChar> getTextAttributes() const;
     QPair<quint8, TChar> getTextAttributes(const QString&) const;
+    std::pair<bool, QString> setUserWindowTitle(const QString& name, const QString& text);
 
 
     QPointer<Host> mpHost;

--- a/src/TLuaInterpreter.cpp
+++ b/src/TLuaInterpreter.cpp
@@ -3593,27 +3593,28 @@ int TLuaInterpreter::openUserWindow(lua_State* L)
 // Documentation: https://wiki.mudlet.org/w/Manual:Lua_Functions#setUserWindowTitle
 int TLuaInterpreter::setUserWindowTitle(lua_State* L)
 {
-    QString name, text;
     if (!lua_isstring(L, 1)) {
         lua_pushfstring(L, "setUserWindowTitle: bad argument #1 type (name as string expected, got %s!)", luaL_typename(L, 1));
         return lua_error(L);
-    } else {
-        name = QString::fromUtf8(lua_tostring(L, 1));
     }
+    QString name = QString::fromUtf8(lua_tostring(L, 1));
 
-    if (!lua_isstring(L, 2)) {
-        lua_pushfstring(L, "setUserWindowTitle: bad argument #2 type (title text as string expected, got %s!)", luaL_typename(L, 2));
-        return lua_error(L);
-    } else {
-        text = QString::fromUtf8(lua_tostring(L, 2));
+    QString title;
+    if (lua_gettop(L) > 1) {
+        if (!lua_isstring(L, 2)) {
+            lua_pushfstring(L, "setUserWindowTitle: bad argument #2 type (title as string is optional, got %s!)", luaL_typename(L, 2));
+            return lua_error(L);
+        }
+        title = QString::fromUtf8(lua_tostring(L, 2));
     }
 
     Host& host = getHostFromLua(L);
-    if (auto [success, message] = mudlet::self()->setUserWindowTitle(&host, name, text); !success) {
+    if (auto [success, message] = host.mpConsole->setUserWindowTitle(name, title); !success) {
         lua_pushnil(L);
         lua_pushfstring(L, message.toUtf8().constData());
         return 2;
     }
+
     lua_pushboolean(L, true);
     return 1;
 }

--- a/src/mudlet.cpp
+++ b/src/mudlet.cpp
@@ -2032,28 +2032,6 @@ bool mudlet::openWindow(Host* pHost, const QString& name, bool loadLayout)
     return false;
 }
 
-std::pair<bool, QString> mudlet::setUserWindowTitle(Host* pHost, const QString& name, const QString& text)
-{
-    if (!pHost || !pHost->mpConsole) {
-        return {false, QString()};
-    }
-    if (name.isEmpty()) {
-        return {false, QStringLiteral("an userwindow cannot have an empty string as its name")};
-    }
-
-    auto hostName(pHost->getName());
-    auto pW = pHost->mpConsole->mDockWidgetMap.value(name);
-    if (pW) {
-        if (text.isEmpty()) {
-            pW->setWindowTitle(tr("User window - %1 - %2").arg(hostName, name));
-            return {true, QString()};
-        }
-        pW->setWindowTitle(text);
-        return {true, QString()};
-    }
-    return {false, QStringLiteral("userwindow name \"%1\" not found").arg(name)};
-}
-
 std::pair<bool, QString> mudlet::createMiniConsole(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height)
 {
     if (!pHost || !pHost->mpConsole) {

--- a/src/mudlet.h
+++ b/src/mudlet.h
@@ -146,7 +146,6 @@ public:
     int getFontSize(Host*, const QString&);
     QSize calcFontSize(Host* pHost, const QString& windowName);
     bool openWindow(Host*, const QString&, bool loadLayout = true);
-    std::pair<bool, QString> setUserWindowTitle(Host* pHost, const QString& name, const QString& text);
     bool setProfileStyleSheet(Host* pHost, const QString& styleSheet);
     std::pair<bool, QString> createMiniConsole(Host*, const QString& windowname, const QString& name, int, int, int, int);
     std::pair<bool, QString> createLabel(Host* pHost, const QString& windowname, const QString& name, int x, int y, int width, int height, bool fillBg, bool clickthrough);


### PR DESCRIPTION
Move the core code to the main `TConsole` for the profile concerned rather than doing it in the `mudlet` singleton. This is part of the policy I trying to put into practice of moving functionality out of the central `mudlet` class when it does not need to be done in that shared between all profiles core.

Allow the second argument to the Lua API `setWindowTitle(...)` to be omitted for`the reset to default case as well as doing that for the empty string case.

Add detection and error reporting for the user trying to set the title on a console that is NOT a user window (and which would not have a title bar).

Also add handling of an error condition that should not be possible in practice but which code analysers might otherwise moan about.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>