### PR TITLE
Small UI tweaks for package manager

### DIFF
--- a/src/dlgPackageManager.cpp
+++ b/src/dlgPackageManager.cpp
@@ -45,6 +45,7 @@ dlgPackageManager::dlgPackageManager(QWidget* parent, Host* pHost)
     connect(mRemoveButton, &QAbstractButton::clicked, this, &dlgPackageManager::slot_remove_packages);
     connect(mpHost->mpConsole, &QWidget::destroyed, this, &dlgPackageManager::close);
     connect(mPackageTable, &QTableWidget::currentItemChanged, this, &dlgPackageManager::slot_item_clicked);
+    connect(mPackageTable, &QTableWidget::itemSelectionChanged, this, &dlgPackageManager::slot_toggle_remove_button);
 
     setWindowTitle(tr("Package Manager - %1").arg(mpHost->getName()));
     mDetailsTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -227,4 +228,14 @@ void dlgPackageManager::fillAdditionalDetails(const QMap<QString, QString>& pack
         value->setAlignment(Qt::AlignLeft);
         ++iter;
     }
+}
+
+void dlgPackageManager::slot_toggle_remove_button()
+{
+    int selectionCount = mPackageTable->selectedItems().count();
+    bool haveSelection = selectionCount != 0;
+
+    mRemoveButton->setEnabled(haveSelection);
+    // let the translations decide whenever it should be 'Remove package', 'Remove packages', or whatever is language-appropriate
+    mRemoveButton->setText(tr("Remove packages", "Button in package manager to remove selected package(s)", selectionCount));
 }

--- a/src/dlgPackageManager.h
+++ b/src/dlgPackageManager.h
@@ -49,6 +49,7 @@ private slots:
     void slot_install_package();
     void slot_remove_packages();
     void slot_item_clicked(QTableWidgetItem*);
+    void slot_toggle_remove_button();
 
 private:
     Ui::package_manager* ui;

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -182,29 +182,20 @@
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QPushButton" name="removeButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
-           <property name="focusPolicy">
-            <enum>Qt::TabFocus</enum>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
            </property>
-           <property name="text">
-            <string>Remove package</string>
-           </property>
-          </widget>
+          </spacer>
          </item>
          <item>
           <widget class="QPushButton" name="installButton">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
            <property name="focusPolicy">
             <enum>Qt::TabFocus</enum>
            </property>
@@ -216,6 +207,29 @@
            </property>
           </widget>
          </item>
+         <item>
+          <widget class="QPushButton" name="removeButton">
+           <property name="focusPolicy">
+            <enum>Qt::TabFocus</enum>
+           </property>
+           <property name="text">
+            <string>Remove packages</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
         </layout>
        </widget>
       </item>
@@ -225,7 +239,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>installButton</tabstop>
   <tabstop>removeButton</tabstop>
   <tabstop>packageTable</tabstop>
  </tabstops>

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -213,7 +213,7 @@
             <enum>Qt::TabFocus</enum>
            </property>
            <property name="text">
-            <string>Remove packages</string>
+            <string>Remove package</string>
            </property>
           </widget>
          </item>

--- a/src/ui/package_manager.ui
+++ b/src/ui/package_manager.ui
@@ -115,10 +115,7 @@
         </property>
         <property name="font">
          <font>
-          <family>DejaVu Sans Mono</family>
           <pointsize>14</pointsize>
-          <weight>75</weight>
-          <bold>true</bold>
          </font>
         </property>
         <property name="text">
@@ -196,7 +193,7 @@
             <enum>Qt::TabFocus</enum>
            </property>
            <property name="text">
-            <string>remove Packages</string>
+            <string>Remove package</string>
            </property>
           </widget>
          </item>
@@ -212,7 +209,7 @@
             <enum>Qt::TabFocus</enum>
            </property>
            <property name="text">
-            <string>Install new Package</string>
+            <string>Install new package</string>
            </property>
            <property name="default">
             <bool>false</bool>


### PR DESCRIPTION
Small UI tweaks for package manager to improve the look'n'feel.

A couple of things I wanted to do but couldn't finish:

* no selection of a package by default
* translate the machine-friendly `created` timestamp to a human-friendly date in their local timezone